### PR TITLE
#5 商品テーブルにuser_idを追加

### DIFF
--- a/backend/infrastructure/prisma/migrations/20250501085440_add_user_id_to_items/migration.sql
+++ b/backend/infrastructure/prisma/migrations/20250501085440_add_user_id_to_items/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `user_id` to the `items` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `items` ADD COLUMN `user_id` CHAR(36) NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE `items` ADD CONSTRAINT `items_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users`(`user_id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/infrastructure/prisma/schema.prisma
+++ b/backend/infrastructure/prisma/schema.prisma
@@ -8,23 +8,28 @@ datasource db {
 }
 
 model User {
-  user_id    String    @id @db.Char(36)
-  name       String    @default("")
-  email      String
-  password   String
-  created_at DateTime  @default(now())
-  updated_at DateTime?
+  userId    String    @id @map("user_id") @db.Char(36)
+  name      String    @default("")
+  email     String
+  password  String
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime? @map("updated_at")
+
+  items Item[]
 
   @@map("users")
 }
 
 model Item {
-  item_id     String    @id @db.Char(36)
-  item_name   String    @default("")
+  itemId      String    @id @map("item_id") @db.Char(36)
+  userId      String    @map("user_id") @db.Char(36)
+  itemName    String    @default("") @map("item_name")
   stock       Boolean   @default(true)
   description String?
-  created_at  DateTime  @default(now())
-  updated_at  DateTime?
+  createdAt   DateTime  @default(now()) @map("created_at")
+  updatedAt   DateTime? @map("updated_at")
+
+  user User? @relation(fields: [userId], references: [userId])
 
   @@map("items")
 }


### PR DESCRIPTION
# 対応内容
- 商品テーブルに購入者を記録する`user_id`を追加
- スキーマファイルのモデル名記述をキャメルに変更