### PR TITLE
#25 Goのlinter警告を修正

### DIFF
--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -1,3 +1,4 @@
+// Package middleware provides HTTP middleware functions for authentication and authorization.
 package middleware
 
 import (
@@ -30,7 +31,7 @@ func AuthMiddleware() echo.MiddlewareFunc {
 				tokenString = parts[1]
 			}
 
-			token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+			token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 				if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 					return nil, jwt.ErrSignatureInvalid
 				}

--- a/backend/validator/validator.go
+++ b/backend/validator/validator.go
@@ -1,3 +1,4 @@
+// Package validator provides custom validation functionality using go-playground/validator.
 package validator
 
 import (
@@ -8,7 +9,7 @@ type CustomValidator struct {
 	validator *validator.Validate
 }
 
-func (cv *CustomValidator) Validate(i interface{}) error {
+func (cv *CustomValidator) Validate(i any) error {
 	return cv.validator.Struct(i)
 }
 


### PR DESCRIPTION
## 概要

go の各ファイルで発生している linter の警告を修正した。

## 変更内容

- package コメントを追加
- interface{}ではなく any を使用するように変更

## 関連 Issue

Closes #25

## 動作確認

- [x] テストコード実行
