### PR TITLE
#43 HTTPS対応とフロントエンドAPI接続修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 
 # gh issue create template body
 /issue-body-template.md
+
+# .pem
+*.pem

--- a/backend/main.go
+++ b/backend/main.go
@@ -25,5 +25,5 @@ func main() {
 	userController := controller.NewUserController(userUsecase)
 	itemController := controller.NewItemController(itemUsecase)
 	e := router.NewRouter(userController, itemController)
-	e.Logger.Fatal(e.Start(":8080"))
+	e.Logger.Fatal(e.StartTLS(":8080", "/go/src/localhost+2.pem", "/go/src/localhost+2-key.pem"))
 }

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -13,7 +13,7 @@ func NewRouter(uc controller.IUserController, ic controller.IItemController) *ec
 	e := echo.New()
 	e.Validator = validator.NewValidator()
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins:     []string{"https://labstack.com", "https://labstack.net", "http://localhost:3000"},
+		AllowOrigins:     []string{"https://labstack.com", "https://labstack.net", "http://localhost:3000", "https://localhost:3000"},
 		AllowHeaders:     []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, echo.HeaderAuthorization},
 		AllowCredentials: true,
 	}))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
     volumes:
       - ./backend/:/go/src/
       - .env:/go/src/.env
+      - ./localhost+2.pem:/go/src/localhost+2.pem:ro
+      - ./localhost+2-key.pem:/go/src/localhost+2-key.pem:ro
     ports:
       - "8080:8080"
     depends_on:
@@ -37,7 +39,9 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./frontend:/app
-      - /app/node_modules
+      - frontend_node_modules:/app/node_modules
+      - ./localhost+2.pem:/app/localhost+2.pem:ro
+      - ./localhost+2-key.pem:/app/localhost+2-key.pem:ro
     ports:
       - "3000:3000"
     tty: true
@@ -113,6 +117,7 @@ services:
 volumes:
   mysql_data:
   test_mysql_data:
+  frontend_node_modules:
 
 networks:
   app_network:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,8 +2,6 @@ FROM node:22
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y vim
-
 COPY package.json package-lock.json ./
 
 RUN npm install

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import tsconfigPaths from "vite-tsconfig-paths";
+import fs from "fs";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -14,10 +15,15 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 3000,
+    https: {
+      key: fs.readFileSync(path.resolve(__dirname, "./localhost+2-key.pem")),
+      cert: fs.readFileSync(path.resolve(__dirname, "./localhost+2.pem")),
+    },
     proxy: {
       "/v1": {
-        target: "http://backend:8080",
+        target: "https://backend:8080",
         changeOrigin: true,
+        secure: false,
       },
     },
   },

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -8,7 +8,7 @@ info:
 servers:
   - url: https://mikatan_knitting/v1
     description: Production
-  - url: http://localhost:8080/v1
+  - url: https://localhost:8080/v1
     description: Local
 paths:
   /items:


### PR DESCRIPTION
## Summary
- フロントエンドのAPI接続エラーを修正
- 環境変数をHTTPからHTTPSに変更
- Docker環境でのHTTPS通信を正常化

## Test plan
- [ ] https://localhost:3000 でフロントエンドが正常に表示される
- [ ] フロントエンドからバックエンドAPIへの接続が成功する
- [ ] アイテム一覧が正常に取得できる

🤖 Generated with [Claude Code](https://claude.ai/code)